### PR TITLE
rename 'sys' to 'util' to compile,

### DIFF
--- a/file/lib/main.js
+++ b/file/lib/main.js
@@ -1,6 +1,10 @@
 var path = require('path');
 var fs = require('fs');
-var sys = require('sys');
+try{
+  var sys = require('util');
+}catch(e){
+  var sys = require('sys');
+}
 
 exports.mkdirs = function (_path, mode, callback) {
   _path = exports.path.abspath(_path);


### PR DESCRIPTION
get rid of silent warnings 

```
The "sys" module is now called "util". It should have a similar interface.
```

related: #14
